### PR TITLE
FIX: typo

### DIFF
--- a/Newsletters.md
+++ b/Newsletters.md
@@ -7,4 +7,4 @@ address can be associated with the correct record.
 
 ![Newsletters Flow](diagrams/newsletters-flow.svg)
 
-Edit [newsletters-flow.drawio](diagrams/newslwtters-flow.drawio) with draw.io
+Edit [newsletters-flow.drawio](diagrams/newsletters-flow.drawio) with draw.io


### PR DESCRIPTION
In this commit, I fix a typo by removing a `w` and replacing it with an `e`.

- [x] improved UX
- [x] facefeels

#likemagic